### PR TITLE
add additional COVID codes as labeled by the CDC

### DIFF
--- a/ValueSet/shc-covid-cvx.json
+++ b/ValueSet/shc-covid-cvx.json
@@ -154,6 +154,50 @@
                },
                "value" : "Pfizer-BioNTech COVID-19 Vaccine"
             }]
+          }, {
+            "code": "510",
+            "display": "COVID-19 IV Non-US Vaccine (BIBP, Sinopharm)",
+            "designation": [{
+                "language": "en-US",
+                "use": {
+                  "system": "http://example.org/fhir/CodeSystem/designation-use",
+                  "use": "consumer-friendly"
+                },
+                "value": "Sinopharm (BIBP) COVID-19 Vaccine"
+            }]
+          }, {
+            "code": "511",
+            "display": "COVID-19 IV Non-US Vaccine (CoronaVac, Sinovac)",
+            "designation": [{
+                "language": "en-US",
+                "use": {
+                  "system": "http://example.org/fhir/CodeSystem/designation-use",
+                  "use": "consumer-friendly"
+                },
+                "value": "Coronavac (Sinovac) COVID-19 Vaccine"
+            }]
+          }, {
+            "code": "211",
+            "display": "COVID-19 vaccine, Subunit, rS-nanoparticle+Matrix-M1 Adjuvant, PF, 0.5 mL",
+            "designation": [{
+                "language": "en-US",
+                "use": {
+                  "system": "http://example.org/fhir/CodeSystem/designation-use",
+                  "use": "consumer-friendly"
+                },
+                "value": "Novavax COVID-19 Vaccine"
+            }]
+          }, {
+            "code": "219",
+            "display": "COVID-19, mRNA, LNP-S, PF, 3 mcg/0.2 mL dose, tris-sucrose",
+            "designation": [{
+                "language": "en-US",
+                "use": {
+                    "system": "http://example.org/fhir/CodeSystem/designation-use",
+                    "use": "consumer-friendly"
+                },
+                "value": "Pfizer-BioNTech COVID-19 Vaccine (EUA labeled) COMIRNATY (BLA labeled)"
+            }]
           }
         ]
       }

--- a/ValueSet/shc-covid-cvx.json
+++ b/ValueSet/shc-covid-cvx.json
@@ -198,6 +198,17 @@
                 },
                 "value": "Pfizer-BioNTech COVID-19 Vaccine (EUA labeled) COMIRNATY (BLA labeled)"
             }]
+          }, {
+            "code": "502",
+            "display": "COVID-19 IV Non-US Vaccine (COVAXIN)",
+            "designation": [{
+                "language": "en-US",
+                "use": {
+                    "system": "http://example.org/fhir/CodeSystem/designation-use",
+                    "use": "consumer-friendly"
+                },
+                "value": "COVAXIN (Bharat) COVID-19 Vaccine"
+            }]
           }
         ]
       }


### PR DESCRIPTION
Nathan Bunker asked me to look at this file and see if we could automate updates to it as the CDC adds codes.  For this pass, I added only COVID codes that were not NOS types.  

I took the CVX Short Description as the "display" and the Product Tradename as the "consumer-friendly".

Happy to take any feedback.