### PR TITLE
Change system URI for the health card type system to include `#`

### DIFF
--- a/input/fsh/health-card.fsh
+++ b/input/fsh/health-card.fsh
@@ -2,7 +2,7 @@ CodeSystem: HealthCardTypeCodeSystem
 Id: health-card
 Title: "Health Card Type Code System"
 Description: "A code system defining various credential types for SMART Health Cards"
-* ^url =  https://smarthealth.cards
+* ^url =  https://smarthealth.cards#
 * ^caseSensitive = false
 * #health-card "A VC designed to convey a \"Health Card\" (i.e., clinical data bound to a subject's identity)"
 * #covid19 "A Health Card designed to convey COVID-19 details"

--- a/input/pagecontent/CodeSystem-health-card-intro.md
+++ b/input/pagecontent/CodeSystem-health-card-intro.md
@@ -1,10 +1,8 @@
-### Usage
+<div class="alert alert-success" role="alert" markdown="1">
+**Implementation note:** In a SMART Health Card, values of the `vc.type` element SHALL be in the format `https://smarthealth.cards#$SOME_CODE`, where `$SOME_CODE` is replaced by one of the codes listed below.
 
-The codes in this code system are used to identify a Health Card's type.
-
-As described in the [SMART Health Card specification](https://spec.smarthealth.cards/#health-cards-are-encoded-as-compact-serialization-json-web-signatures-jws), all SMART Health Cards have a type of `https://smarthealth.cards#health-card`.
-
-Additionally, SMART Health Cards may also be annotated with additional, more granular types, such as `https://smarthealth.cards#covid19`.
+For example, all SMART Health Cards have the value `https://smarthealth.cards#health-card` in `vc.type` array. Additional values may also be included in this array. For more information, please see the [SMART Health Card specification](https://spec.smarthealth.cards/#health-cards-are-encoded-as-compact-serialization-json-web-signatures-jws).
+</div>
 
 <a href="https://github.com/dvci/shc-terminology/blob/main/input/fsh/health-card.fsh" class="btn btn-primary btn-lg">Edit on GitHub</a>
 


### PR DESCRIPTION
This is to try to make it clearer how the code system is supposed to be used.

Note: it is **not** directly used in FHIR resources -- only in SMART Health Card JSON.

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/110426/189405318-532b65f1-6011-4d02-a5a3-c14cc618af51.png">
